### PR TITLE
Fixes doc string

### DIFF
--- a/grpc4bmi/bmi_client_docker.py
+++ b/grpc4bmi/bmi_client_docker.py
@@ -47,7 +47,6 @@ class BmiClientDocker(BmiClient):
         delay (int): Seconds to wait for Docker container to startup, before connecting to it
         timeout (int): Seconds to wait for gRPC client to connect to server
         extra_volumes (Dict[str,Dict]): Extra volumes to attach to Docker container.
-
             The key is either the hosts path or a volume name and the value is a dictionary with the keys:
 
             - ``bind`` The path to mount the volume inside the container
@@ -57,7 +56,7 @@ class BmiClientDocker(BmiClient):
 
             .. code-block:: python
 
-                    {'/data/shared/forcings/': {'bind': '/forcings', 'mode': 'ro'}}
+                {'/data/shared/forcings/': {'bind': '/forcings', 'mode': 'ro'}}
 
     """
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(name="grpc4bmi",
-      version="0.3",
+      version="0.3.1",
       author="Gijs van den Oord",
       author_email="g.vandenoord@esciencecenter.nl",
       description="Run your BMI implementation in a separate process and expose it as BMI-python with GRPC",


### PR DESCRIPTION
Of https://grpc4bmi.readthedocs.io/en/0.2.x/python_api.html#grpc4bmi.bmi_client_docker.BmiClientDocker

Refs #73 