### PR TITLE
Fixes semver deprecation warning

### DIFF
--- a/grpc4bmi/bmi_client_singularity.py
+++ b/grpc4bmi/bmi_client_singularity.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import logging
 
-import semver
+from semver import VersionInfo
 
 from grpc4bmi.bmi_grpc_client import BmiClient
 from grpc4bmi.utils import stage_config_file
@@ -18,7 +18,7 @@ def check_singularity_version():
     (stdout, _stderr) = p.communicate()
     if p.returncode != 0:
         raise Exception('Unable to determine singularity version')
-    if not semver.match(stdout.decode('utf-8'), REQUIRED_SINGULARITY_VERSION):
+    if not VersionInfo.parse(stdout.decode('utf-8')).match(REQUIRED_SINGULARITY_VERSION):
         raise Exception(f'Wrong version of singularity found, require version {REQUIRED_SINGULARITY_VERSION}')
     return True
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(name="grpc4bmi",
-      version="0.3",
+      version="0.3.1",
       author="Gijs van den Oord",
       author_email="g.vandenoord@esciencecenter.nl",
       description="Run your BMI implementation in a separate process and expose it as BMI-python with GRPC",


### PR DESCRIPTION
Singularity client was giving

```
.../grpc4bmi/grpc4bmi/bmi_client_singularity.py:21: DeprecationWarning: Function 'semver.match' is deprecated. Deprecated since version 2.10.0.  This function will be removed in semver 3. Use the respective 'semver.VersionInfo.match' instead.
    if not semver.match(stdout.decode('utf-8'), REQUIRED_SINGULARITY_VERSION):
```

This PR resolves it