### PR TITLE
Adds logs() to BmiClientSingularity and BmiClientDocker

### DIFF
--- a/grpc4bmi/bmi_client_docker.py
+++ b/grpc4bmi/bmi_client_docker.py
@@ -7,25 +7,7 @@ import docker
 from typeguard import check_argument_types, qualified_name
 
 from grpc4bmi.bmi_grpc_client import BmiClient
-
-
-class DeadDockerContainerException(ChildProcessError):
-    """
-    Exception for when a Docker container has died.
-
-    Args:
-        message (str): Human readable error message
-        exitcode (int): The non-zero exit code of the container
-        logs (str): Logs the container produced
-
-    """
-
-    def __init__(self, message, exitcode, logs, *args):
-        super().__init__(message, *args)
-        #: Exit code of container
-        self.exitcode = exitcode
-        #: Stdout and stderr of container
-        self.logs = logs
+from grpc4bmi.exceptions import DeadContainerException
 
 
 class BmiClientDocker(BmiClient):
@@ -103,7 +85,7 @@ class BmiClientDocker(BmiClient):
                 exitcode = self.container.attrs["State"]["ExitCode"]
                 logs = self.logs()
                 msg = f'Failed to start Docker container with image {image}, Container log: {logs}'
-                raise DeadDockerContainerException(msg, exitcode, logs)
+                raise DeadContainerException(msg, exitcode, logs)
 
         super(BmiClientDocker, self).__init__(BmiClient.create_grpc_channel(port=port, host=host), timeout=timeout)
 

--- a/grpc4bmi/bmi_client_docker.py
+++ b/grpc4bmi/bmi_client_docker.py
@@ -19,6 +19,7 @@ class DeadDockerContainerException(ChildProcessError):
         logs (str): Logs the container produced
 
     """
+
     def __init__(self, message, exitcode, logs, *args):
         super().__init__(message, *args)
         #: Exit code of container
@@ -62,6 +63,7 @@ class BmiClientDocker(BmiClient):
 
     See :py:class:`grpc4bmi.bmi_client_singularity.BmiClientSingularity` for examples using `input_dirs` and `work_dir`.
     """
+
     def __init__(self, image: str, work_dir: str, image_port=50051, host=None,
                  input_dirs: Iterable[str] = tuple(),
                  user=os.getuid(), remove=False, delay=5,
@@ -111,3 +113,10 @@ class BmiClientDocker(BmiClient):
 
     def get_value_ref(self, var_name):
         raise NotImplementedError("Cannot exchange memory references across process boundary")
+
+    def logs(self) -> str:
+        """Returns complete combined stdout and stderr written by the Docker container.
+        """
+        if hasattr(self, "container"):
+            return self.container.logs().decode('utf8')
+        return ''

--- a/grpc4bmi/bmi_client_docker.py
+++ b/grpc4bmi/bmi_client_docker.py
@@ -101,7 +101,7 @@ class BmiClientDocker(BmiClient):
             self.container.reload()
             if self.container.status == 'exited':
                 exitcode = self.container.attrs["State"]["ExitCode"]
-                logs = self.container.logs()
+                logs = self.logs()
                 msg = f'Failed to start Docker container with image {image}, Container log: {logs}'
                 raise DeadDockerContainerException(msg, exitcode, logs)
 

--- a/grpc4bmi/bmi_client_singularity.py
+++ b/grpc4bmi/bmi_client_singularity.py
@@ -25,7 +25,7 @@ def check_singularity_version():
 
 class DeadSingularityContainerException(ChildProcessError):
     """
-    Exception for when a Docker container has died.
+    Exception for when a Singularity container has died.
 
     Args:
         message (str): Human readable error message

--- a/grpc4bmi/bmi_client_singularity.py
+++ b/grpc4bmi/bmi_client_singularity.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import time
 from os.path import abspath
-from typing import Iterable, BinaryIO, TextIO, Union, Literal
+from typing import Iterable, BinaryIO, TextIO, Union
 
 import semver
 from typeguard import check_argument_types, qualified_name

--- a/grpc4bmi/bmi_client_singularity.py
+++ b/grpc4bmi/bmi_client_singularity.py
@@ -10,7 +10,7 @@ from typeguard import check_argument_types, qualified_name
 
 from grpc4bmi.bmi_grpc_client import BmiClient
 
-REQUIRED_SINGULARITY_VERSION = '>=3.6.0'
+REQUIRED_SINGULARITY_VERSION = '3.6.0'
 
 
 def check_singularity_version():
@@ -18,8 +18,10 @@ def check_singularity_version():
     (stdout, _stderr) = p.communicate()
     if p.returncode != 0:
         raise Exception('Unable to determine singularity version')
-    if not semver.match(stdout.decode('utf-8').replace('_', '-'), REQUIRED_SINGULARITY_VERSION):
-        raise Exception(f'Wrong version of singularity found, require version {REQUIRED_SINGULARITY_VERSION}')
+    local_version = semver.VersionInfo.parse(stdout.decode('utf-8').replace('_', '-'))
+    if local_version < REQUIRED_SINGULARITY_VERSION:
+        raise Exception(f'Wrong version ({local_version}) of singularity found, '
+                        f'require version {REQUIRED_SINGULARITY_VERSION}')
     return True
 
 

--- a/grpc4bmi/exceptions.py
+++ b/grpc4bmi/exceptions.py
@@ -1,0 +1,21 @@
+
+class DeadContainerException(ChildProcessError):
+    """
+    Exception for when a container has died.
+
+    Args:
+        message (str): Human readable error message
+        exitcode (int): The non-zero exit code of the container
+        logs (str): Logs the container produced
+
+    """
+    def __init__(self, message, exitcode, logs, *args):
+        super().__init__(message, *args)
+        #: Exit code of container
+        self.exitcode = exitcode
+        #: Stdout and stderr of container
+        self.logs = logs
+
+
+class SingularityVersionException(ValueError):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(name="grpc4bmi",
-      version="0.2.12",
+      version="0.2.13",
       author="Gijs van den Oord",
       author_email="g.vandenoord@esciencecenter.nl",
       description="Run your BMI implementation in a separate process and expose it as BMI-python with GRPC",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name="grpc4bmi",
           "numpy",
           "docker",
           "basic-modeling-interface",
-          "semver",
+          "semver>=2.10.0",
           "typeguard",
       ],
       extras_require={

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -3,7 +3,8 @@ from io import BytesIO
 import docker
 import pytest
 
-from grpc4bmi.bmi_client_docker import BmiClientDocker, DeadDockerContainerException
+from grpc4bmi.bmi_client_docker import BmiClientDocker
+from grpc4bmi.exceptions import DeadContainerException
 
 walrus_docker_image = 'ewatercycle/walrus-grpc4bmi:v0.2.0'
 
@@ -79,12 +80,12 @@ class TestBmiClientDocker:
 
     def test_container_start_failure(self, exit_container, tmp_path):
         expected = r"Failed to start Docker container with image"
-        with pytest.raises(DeadDockerContainerException, match=expected) as excinfo:
+        with pytest.raises(DeadContainerException, match=expected) as excinfo:
             BmiClientDocker(image=exit_container, work_dir=str(tmp_path))
 
         assert excinfo.value.exitcode == 25
-        assert b'my stderr' in excinfo.value.logs
-        assert b'my stdout' in excinfo.value.logs
+        assert 'my stderr' in excinfo.value.logs
+        assert 'my stdout' in excinfo.value.logs
 
     def test_same_inputdir_and_workdir(self, tmp_path):
         some_dir = str(tmp_path)

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -105,3 +105,9 @@ class TestBmiClientDocker:
         some_dir = str(tmp_path)
         with pytest.raises(TypeError, match='must be collections.abc.Iterable; got int instead'):
             BmiClientDocker(image=walrus_docker_image, input_dirs=42, work_dir=some_dir)
+
+    def test_logs(self, walrus_model, capfd):
+        logs = walrus_model.logs()
+
+        assert 'R[write to console]' in logs
+        assert 'R[write to console]' not in capfd.readouterr().out

--- a/test/test_singularity.py
+++ b/test/test_singularity.py
@@ -187,24 +187,18 @@ class TestRedirectOutput:
         return hello_image
 
     def test_default(self, image, tmp_path, capfd):
-        with pytest.raises(DeadSingularityContainerException):
+        with pytest.raises(DeadSingularityContainerException) as excinf:
             BmiClientSingularity(image=image, work_dir=str(tmp_path), delay=2)
 
-        assert self.EXPECTED in capfd.readouterr().out
-
-    def test_textfile(self, image, tmp_path):
-        mylog = tmp_path / 'mylog.txt'
-
-        with mylog.open('w') as f, pytest.raises(DeadSingularityContainerException):
-            BmiClientSingularity(image=image, work_dir=str(tmp_path), stdout=f, delay=2)
-
-        assert self.EXPECTED in mylog.read_text()
+        assert self.EXPECTED not in capfd.readouterr().out
+        assert self.EXPECTED in excinf.value.logs
 
     def test_devnull(self, image, tmp_path, capfd):
-        with pytest.raises(DeadSingularityContainerException):
-            BmiClientSingularity(image=image, work_dir=str(tmp_path), stdout=subprocess.DEVNULL, delay=2)
+        with pytest.raises(DeadSingularityContainerException) as excinf:
+            BmiClientSingularity(image=image, work_dir=str(tmp_path), capture_logs=False, delay=2)
 
         assert self.EXPECTED not in capfd.readouterr().out
+        assert self.EXPECTED not in excinf.value.logs
 
 
 @pytest.fixture

--- a/test/test_singularity.py
+++ b/test/test_singularity.py
@@ -8,7 +8,8 @@ from grpc import RpcError
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbformat.v4 import new_notebook, new_code_cell
 
-from grpc4bmi.bmi_client_singularity import BmiClientSingularity, DeadSingularityContainerException
+from grpc4bmi.bmi_client_singularity import BmiClientSingularity
+from grpc4bmi.exceptions import DeadContainerException
 from test.conftest import write_config, write_datafile
 
 IMAGE_NAME = "docker://ewatercycle/walrus-grpc4bmi:v0.2.0"
@@ -187,14 +188,14 @@ class TestRedirectOutput:
         return hello_image
 
     def test_default(self, image, tmp_path, capfd):
-        with pytest.raises(DeadSingularityContainerException) as excinf:
+        with pytest.raises(DeadContainerException) as excinf:
             BmiClientSingularity(image=image, work_dir=str(tmp_path), delay=2)
 
         assert self.EXPECTED not in capfd.readouterr().out
         assert self.EXPECTED in excinf.value.logs
 
     def test_devnull(self, image, tmp_path, capfd):
-        with pytest.raises(DeadSingularityContainerException) as excinf:
+        with pytest.raises(DeadContainerException) as excinf:
             BmiClientSingularity(image=image, work_dir=str(tmp_path), capture_logs=False, delay=2)
 
         assert self.EXPECTED not in capfd.readouterr().out


### PR DESCRIPTION
Captures stdout or stderr from container in temp file which can be read with `BmiClientSingularity.logs()`

No longer does BmiClientSingularity leak output written to stdout or stderr from container to python/notebook.

This is similar behavior to BmiClientDocker which always captured output from container in `docker logs`.