### PR TITLE
Support 1.1.5-2.el8 apptainer version

### DIFF
--- a/grpc4bmi/bmi_client_apptainer.py
+++ b/grpc4bmi/bmi_client_apptainer.py
@@ -17,7 +17,7 @@ SUPPORTED_APPTAINER_VERSIONS = '>=1.0.0-rc.2'  # First apptainer release with bi
 
 def check_apptainer_version_string(version_output: str) -> bool:
     version = version_output.split(' ').pop()
-    local_version = Version(version)
+    local_version = Version(version.replace('.el', ''))
     if local_version not in SpecifierSet(SUPPORTED_APPTAINER_VERSIONS):
         raise ApptainerVersionException(f'Unsupported version ({version_output}) of apptainer found, '
                                         f'supported versions {SUPPORTED_APPTAINER_VERSIONS}')

--- a/grpc4bmi/bmi_client_singularity.py
+++ b/grpc4bmi/bmi_client_singularity.py
@@ -18,7 +18,7 @@ SUPPORTED_APPTAINER_VERSIONS = '>=1.0.0-rc.2'  # First apptainer release with bi
 
 def check_singularity_version_string(version_output: str) -> bool:
     (app, _, version) = version_output.split(' ')
-    local_version = Version(version)
+    local_version = Version(version.replace('.el', ''))
     if app == 'singularity' and local_version not in SpecifierSet(SUPPORTED_SINGULARITY_VERSIONS):
         raise SingularityVersionException(f'Unsupported version ({version_output}) of singularity found, '
                                           f'supported versions {SUPPORTED_SINGULARITY_VERSIONS}')

--- a/test/test_apptainer.py
+++ b/test/test_apptainer.py
@@ -14,6 +14,7 @@ class Test_check_apptainer_version_string:
         ('apptainer version 1.0.3'),
         ('apptainer version 1.1.0-rc.3'),
         ('apptainer version 1.1.2'),
+        ('apptainer version 1.1.5-2.el8'),
     ])
     def test_ok(self, test_input: str):
         result = check_apptainer_version_string(test_input)

--- a/test/test_apptainer.py
+++ b/test/test_apptainer.py
@@ -14,6 +14,7 @@ class Test_check_apptainer_version_string:
         ('apptainer version 1.0.3'),
         ('apptainer version 1.1.0-rc.3'),
         ('apptainer version 1.1.2'),
+        # From snellius cluster at SURF.
         ('apptainer version 1.1.5-2.el8'),
     ])
     def test_ok(self, test_input: str):

--- a/test/test_singularity.py
+++ b/test/test_singularity.py
@@ -235,6 +235,7 @@ class Test_check_singularity_version_string:
         ('apptainer version 1.0.3'),
         ('apptainer version 1.1.0-rc.3'),
         ('apptainer version 1.1.2'),
+        ('apptainer version 1.1.5-2.el8'),
     ])
     def test_ok(self, test_input: str):
         result = check_singularity_version_string(test_input)

--- a/test/test_singularity.py
+++ b/test/test_singularity.py
@@ -235,6 +235,7 @@ class Test_check_singularity_version_string:
         ('apptainer version 1.0.3'),
         ('apptainer version 1.1.0-rc.3'),
         ('apptainer version 1.1.2'),
+        # From snellius cluster at SURF.
         ('apptainer version 1.1.5-2.el8'),
     ])
     def test_ok(self, test_input: str):


### PR DESCRIPTION
Versions of singularity and apptainer are checked using https://packaging.pypa.io/en/stable/version.html
It however raises `packaging.version.InvalidVersion: Invalid version: '1.1.5-2.el8'` error.
So this PR rewrites the version so it is compatible.

Fixes #88 