### PR TITLE
Fix direct dependency forbidden error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        pip install -e .[dev,R]
+        pip install -r dev-requirements.txt
+        pip install -e .[R]
     - name: Setup Apptainer
       uses: eWaterCycle/setup-apptainer@v2
       with:

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ python3 -m venv .venv
 . venv/bin/activate
 # Make sure latest pip and wheel are install
 pip install -U pip wheel
-pip install -e .[dev]
+pip install -r dev-requirements.txt
 # For R integration also install the R extras with
 pip install -e .[R]
 # For building docs (cd docs && make html) also install the docs extras with

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+-e .[dev]
+# Dependencies which are URLs can not be part 
+# of pyproject.toml:project.optional-dependencies:dev
+# so they are listed here
+bmi-heat@https://github.com/csdms/bmi-example-python/archive/refs/heads/master.zip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dev = [
     "pytest-cov",
     "coverage[toml]",
     "grpcio-tools", # Used to generate Python bindings from proto file
-    "bmi-heat@https://github.com/csdms/bmi-example-python/archive/refs/heads/master.zip",
     "nbconvert",
     "ipykernel",
     "nbformat",


### PR DESCRIPTION
Uploading to pypi failed, this PR fixes it.

Full error of `twine upload dist/*`:

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         Invalid value for requires_dist. Error: Can't have direct dependency: "bmi-heat @
         https://github.com/csdms/bmi-example-python/archive/refs/heads/master.zip ; extra == 'dev'"
```

Tested by uploading to https://test.pypi.org/project/grpc4bmi/0.4.0/#files with `twine upload --repository testpypi dist/*`. 
The package could be installed using `pip install -i https://test.pypi.org/simple/ --no-deps grpc4bmi==0.4.0` or `pip install -i https://test.pypi.org/simple/ --no-deps --use-feature=no-binary-enable-wheel-cache grpc4bmi==0.4.0` for wheel and sdist respectivly.
