### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ WORKDIR /opt/grpc
 RUN git submodule update --init --recursive
 WORKDIR /opt/grpc/cmake/_build
 RUN cmake ../.. \
-    -DgRPC_INSTALL=ON \
-    -DgRPC_SSL_PROVIDER=package \
-    -DgRPC_BUILD_TESTS=OFF \
-    -DBUILD_SHARED_LIBS=ON
-RUN make install
+        -DgRPC_INSTALL=ON \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_BUILD_TESTS=OFF \
+        -DBUILD_SHARED_LIBS=ON && \
+    make install && \
+    make clean
 
 # Build bmi-c from source
 RUN git clone --depth=1 https://github.com/eWaterCycle/grpc4bmi.git /opt/grpc4bmi

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM ubuntu:24.04
 LABEL author="Gijs van den Oord"
 LABEL email="g.vandenoord@esciencecenter.nl"
+LABEL org.opencontainers.image.source="https://github.com/eWaterCycle/grpc4bmi"
 
 ENV GRPC_VERSION="1.66.1"
 ENV BMIC_VERSION="2.1.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y \
     libtool \
     make \
     pkg-config \
-    wget
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
 # Build grpc from source
 RUN git clone -b $(curl -L https://grpc.io/release) --depth=1 https://github.com/grpc/grpc /opt/grpc

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN cmake ../.. \
     make install && \
     make clean
 
-# Build bmi-c from source
+# Build bmi-c and bmi-cxx from source
 RUN git clone --branch v${BMIC_VERSION} https://github.com/csdms/bmi-c /opt/bmi-c
 WORKDIR /opt/bmi-c/_build
 RUN cmake .. && \
@@ -49,6 +49,8 @@ WORKDIR /opt/bmi-cxx/_build
 RUN cmake .. && \
     make install && \
     make clean
+
+RUN ldconfig
 
 # Build grpc4bmi from source
 RUN git clone --branch update-dockerfile --depth 1 https://github.com/csdms/grpc4bmi /opt/grpc4bmi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # DockerFile for grpc4bmi. Installs the C++ bindings in the /usr/local prefix directory in the container. If you are
 # planning to run a container with your BMI-enabled model and communicate with it using grpc4bmi, you can use this as a
 # base image for your model
-FROM ubuntu:bionic
+FROM ubuntu:24.04
 MAINTAINER Gijs van den Oord <g.vandenoord@esciencecenter.nl>
 RUN apt-get update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,7 @@ RUN cmake .. && \
 RUN ldconfig
 
 # Build grpc4bmi from source
-RUN git clone --branch update-dockerfile --depth 1 https://github.com/csdms/grpc4bmi /opt/grpc4bmi
-WORKDIR /opt/grpc4bmi
-RUN git submodule update --init
+COPY . /opt/grpc4bmi
 WORKDIR /opt/grpc4bmi/cpp/_build
 RUN cmake .. -DCMAKE_CXX_STANDARD=17 && \
     make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     gfortran \
     git \
     libtool \
+    libssl-dev \
     make \
     pkg-config \
     wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ LABEL author="Gijs van den Oord"
 LABEL email="g.vandenoord@esciencecenter.nl"
 
 ENV GRPC_VERSION="1.66.1"
+ENV BMIC_VERSION="2.1.2"
+ENV BMICXX_VERSION="2.0.2"
 
 # Prerequisite packages
 RUN apt-get update && apt-get install -y \
@@ -37,13 +39,16 @@ RUN cmake ../.. \
     make clean
 
 # Build bmi-c from source
-RUN git clone --depth=1 https://github.com/eWaterCycle/grpc4bmi.git /opt/grpc4bmi
-WORKDIR /opt/grpc4bmi
-RUN git submodule update --init --recursive
-RUN mkdir -p /opt/grpc4bmi/cpp/bmi-c/build
-WORKDIR /opt/grpc4bmi/cpp/bmi-c/build
-RUN cmake ..
-RUN make install
+RUN git clone --branch v${BMIC_VERSION} https://github.com/csdms/bmi-c /opt/bmi-c
+WORKDIR /opt/bmi-c/_build
+RUN cmake .. && \
+    make install && \
+    make clean
+RUN git clone --branch v${BMICXX_VERSION} https://github.com/csdms/bmi-cxx /opt/bmi-cxx
+WORKDIR /opt/bmi-cxx/_build
+RUN cmake .. && \
+    make install && \
+    make clean
 
 # Build grpc4bmi from source
 RUN mkdir -p /opt/grpc4bmi/cpp/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM ubuntu:24.04
 LABEL author="Gijs van den Oord"
 LABEL email="g.vandenoord@esciencecenter.nl"
 
+ENV GRPC_VERSION="1.66.1"
+
 # Prerequisite packages
 RUN apt-get update && apt-get install -y \
     automake \
@@ -21,11 +23,15 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Build grpc from source
-RUN git clone -b $(curl -L https://grpc.io/release) --depth=1 https://github.com/grpc/grpc /opt/grpc
+RUN git clone -b ${GRPC_VERSION} --depth 1 https://github.com/grpc/grpc /opt/grpc
 WORKDIR /opt/grpc
 RUN git submodule update --init --recursive
-RUN make install
-WORKDIR third_party/protobuf
+WORKDIR /opt/grpc/cmake/_build
+RUN cmake ../.. \
+    -DgRPC_INSTALL=ON \
+    -DgRPC_SSL_PROVIDER=package \
+    -DgRPC_BUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=ON
 RUN make install
 
 # Build bmi-c from source

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,20 @@
 FROM ubuntu:24.04
 LABEL author="Gijs van den Oord"
 LABEL email="g.vandenoord@esciencecenter.nl"
-RUN apt-get update
 
 # Prerequisite packages
-RUN apt-get install -y wget git build-essential g++ make cmake curl automake libtool pkg-config gfortran
+RUN apt-get update && apt-get install -y \
+    wget \
+    git \
+    build-essential \
+    g++ \
+    make \
+    cmake \
+    curl \
+    automake \
+    libtool \
+    pkg-config \
+    gfortran
 
 # Build grpc from source
 RUN git clone -b $(curl -L https://grpc.io/release) --depth=1 https://github.com/grpc/grpc /opt/grpc

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,17 @@ LABEL email="g.vandenoord@esciencecenter.nl"
 
 # Prerequisite packages
 RUN apt-get update && apt-get install -y \
-    wget \
-    git \
+    automake \
     build-essential \
-    g++ \
-    make \
     cmake \
     curl \
-    automake \
+    g++ \
+    gfortran \
+    git \
     libtool \
+    make \
     pkg-config \
-    gfortran
+    wget
 
 # Build grpc from source
 RUN git clone -b $(curl -L https://grpc.io/release) --depth=1 https://github.com/grpc/grpc /opt/grpc

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Build grpc from source
-RUN git clone -b ${GRPC_VERSION} --depth 1 https://github.com/grpc/grpc /opt/grpc
+RUN git clone -b v${GRPC_VERSION} --depth 1 https://github.com/grpc/grpc /opt/grpc
 WORKDIR /opt/grpc
 RUN git submodule update --init --recursive
 WORKDIR /opt/grpc/cmake/_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,9 @@ RUN apt-get update && apt-get install -y \
     wget \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Build grpc from source
-RUN git clone -b v${GRPC_VERSION} --depth 1 https://github.com/grpc/grpc /opt/grpc
-WORKDIR /opt/grpc
-RUN git submodule update --init --recursive
+# Build grpc from source (removing git history saves 1.7 GB)
+RUN git clone --branch v${GRPC_VERSION} --depth 1 --recurse-submodules https://github.com/grpc/grpc /opt/grpc && \
+    rm -rf /opt/grpc/.git
 WORKDIR /opt/grpc/cmake/_build
 RUN cmake ../.. \
         -DgRPC_INSTALL=ON \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     make \
     pkg-config \
+    vim-tiny \
     wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # planning to run a container with your BMI-enabled model and communicate with it using grpc4bmi, you can use this as a
 # base image for your model
 FROM ubuntu:24.04
-MAINTAINER Gijs van den Oord <g.vandenoord@esciencecenter.nl>
+LABEL author="Gijs van den Oord"
+LABEL email="g.vandenoord@esciencecenter.nl"
 RUN apt-get update
 
 # Prerequisite packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,14 @@ RUN cmake .. && \
     make clean
 
 # Build grpc4bmi from source
-RUN mkdir -p /opt/grpc4bmi/cpp/build
-WORKDIR /opt/grpc4bmi/cpp/build
-RUN cmake ..
-RUN make install
+RUN git clone --branch update-dockerfile --depth 1 https://github.com/csdms/grpc4bmi /opt/grpc4bmi
+WORKDIR /opt/grpc4bmi
+RUN git submodule update --init
+WORKDIR /opt/grpc4bmi/cpp/_build
+RUN cmake .. && \
+    make && \
+    ctest && \
+    make install && \
+    make clean
+
+WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     vim-tiny \
     wget \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Build grpc from source
 RUN git clone -b v${GRPC_VERSION} --depth 1 https://github.com/grpc/grpc /opt/grpc

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # planning to run a container with your BMI-enabled model and communicate with it using grpc4bmi, you can use this as a
 # base image for your model
 FROM ubuntu:24.04
-LABEL author="Gijs van den Oord"
-LABEL email="g.vandenoord@esciencecenter.nl"
+LABEL maintainer="eWaterCycle <ewatercycle@esciencecenter.nl>"
 LABEL org.opencontainers.image.source="https://github.com/eWaterCycle/grpc4bmi"
 
 ENV GRPC_VERSION="1.66.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN cmake ../.. \
         -DgRPC_INSTALL=ON \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_BUILD_TESTS=OFF \
+        -DCMAKE_CXX_STANDARD=17 \
         -DBUILD_SHARED_LIBS=ON && \
     make install && \
     make clean
@@ -57,7 +58,7 @@ RUN git clone --branch update-dockerfile --depth 1 https://github.com/csdms/grpc
 WORKDIR /opt/grpc4bmi
 RUN git submodule update --init
 WORKDIR /opt/grpc4bmi/cpp/_build
-RUN cmake .. && \
+RUN cmake .. -DCMAKE_CXX_STANDARD=17 && \
     make && \
     ctest && \
     make install && \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ find_library(GRPCREFLECTION grpc++_reflection)
 find_library(GRPCLIB grpc CONFIG REQUIRED)
 message(STATUS "Using gRPC ${GRPCLIB_VERSION}")
 find_package(PkgConfig REQUIRED)
+pkg_check_modules(ABSL_CHECK REQUIRED IMPORTED_TARGET absl_check)
 pkg_check_modules(BMI REQUIRED IMPORTED_TARGET bmic bmicxx)
 message(STATUS "Using BMI ${BMI_VERSION}")
 
@@ -52,6 +53,7 @@ target_link_libraries(
     ${GRPCREFLECTION}
     ${GRPC}
     ${PROTOBUF_LIBRARY}
+    ${ABSL_CHECK_LINK_LIBRARIES}
 )
 set_target_properties(grpc4bmi PROPERTIES PUBLIC_HEADER "bmi_cpp_extension.h;bmi_c_wrapper.h;bmi_grpc_server.h;${GRPC_HDR_FILES}")
 add_subdirectory (test)


### PR DESCRIPTION
This PR updates the Dockerfile used to build the grpc4bmi C++ server.

In this set of changes, I tried to use some of the latest [best practices](https://docs.docker.com/build/building/best-practices/) for Dockerfiles. I chose to build on the most recent Ubuntu LTS release image, as well as a recent version of gRPC.

There are two changes I made that may raise questions, both related to the abseil library used by gRPC.
1. To get the version of abseil used by gRPC to work, I had to set stdc++17 in both gRPC and grpc4bmi.
2. A subset of abseil libraries (absl_check) couldn't be found by the linker, so I added them manually to `CMakeLists.txt`.

I hope this is helpful, and I welcome any comments!